### PR TITLE
RIP TJournal

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
 		</div>
 		<h2>Узнать больше</h2>
 		<ul>
-			<li><a href="https://tjournal.ru/tech/427610-putevoditel-po-fediverse">«Путеводитель по Fediverse»</a> — статья в TJournal.</li>
+			<li><a href="https://web.archive.org/web/20220905175336/https://tjournal.ru/tech/427610-putevoditel-po-fediverse">«Путеводитель по Fediverse»</a> — статья в TJournal (Web Archive).</li>
 			<li><a href="https://mastodon.ml/@zloygik/105865187342581867">«Рекомендации для новичков, которые только пришли в Мастодон и не знают, что делать дальше (v. 2.0)»</a> — серия постов в блоге Злой Гик.</li>
 			<li><a href="https://habr.com/ru/post/345402/">«Не ходи в Fediverse, там тебя ждут неприятности. — Ну как же туда не ходить? Они же ждут»</a> — статья на Хабре.</li>
 			<li><a href="https://habr.com/ru/users/s4n2a/posts/">«Мифы и легенды древней Fediverse»</a> — статья на Хабре.</li>


### PR DESCRIPTION
Changing link from TJournal to Web Archive copy of TJournal.

Shame on you, RKN.