### PR TITLE
#25 Replacing no longer working index.community with official Mastodon catalogue link.

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
 		</ul>
 		<h2>Информационные ресурсы</h2>
 		<ul>
-			<li><a href="https://ru.index.community">«RU Fedi»</a> — каталог серверов и групп русскоязычного созвездия Fediverse.</li>
+			<li><a href="https://joinmastodon.org/ru/servers">Официальный каталог серверов Mastodon</a>.</li>
 			<li><a href="https://fedi.life/social.html">«Fedi.life»</a> — ресурс с вводной информацией про популярные сети Fediverse.</li>
 		</ul>
 	</div>


### PR DESCRIPTION
Replacing no longer working index.community with official Mastodon catalogue link.

Closes #25.